### PR TITLE
integrate phrase

### DIFF
--- a/.phrase.yml
+++ b/.phrase.yml
@@ -1,0 +1,23 @@
+phrase:
+  pull:
+    targets:
+    - file: ./Sources/UI/Resources/<locale_name>.lproj/Localizable.strings
+      project_id: 907a05850acd3c14399a1d166db20d7a
+      params:
+        file_format: strings
+        encoding: "UTF-8"
+        fallback_locale_id: da12d11a9caeca774463f3c6e179ad20
+        include_empty_translations: true
+        format_options:
+            convert_placeholder: true
+            include_pluralized_keys: false
+    - file: ./Sources/UI/Resources/<locale_name>.lproj/Localizable.stringsdict
+      project_id: 907a05850acd3c14399a1d166db20d7a
+      params:
+        file_format: stringsdict
+        encoding: "UTF-8"
+        fallback_locale_id: da12d11a9caeca774463f3c6e179ad20
+        include_empty_translations: true
+        format_options:
+            convert_placeholder: true
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Initital project setup APPS-569
 * Add Example APPS-581
 * Network Layer APPS-588
+* Phrase Integration APPS APPS-583
 
 ### Updated
 * realm/SwiftLint 0.50.3 (was 0.50.0)

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "SnabblePay",
+    defaultLocalization: "en",
     platforms: [
         .iOS(.v15)
     ],
@@ -46,6 +47,14 @@ let package = Package(
             resources: [
                 .process("Resources")
             ]
-        )
+        ),
+        .testTarget(
+            name: "SnabblePayUITests",
+            dependencies: ["SnabblePayCore", "SnabblePayUI"],
+            path: "Tests/UI",
+            resources: [
+                .process("Resources")
+            ]
+        ),
     ]
 )

--- a/Sources/UI/Example.swift
+++ b/Sources/UI/Example.swift
@@ -8,5 +8,5 @@
 import UIKit
 
 enum Example {
-    static var text = "Example"
+    static var text = String(localized: "SnabblePay.Example", bundle: .module)
 }

--- a/Sources/UI/Resources/de.lproj/Localizable.strings
+++ b/Sources/UI/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"SnabblePay.Example" = "Beispiel";
+

--- a/Sources/UI/Resources/de.lproj/Localizable.stringsdict
+++ b/Sources/UI/Resources/de.lproj/Localizable.stringsdict
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+  <dict/>
+</plist>

--- a/Sources/UI/Resources/en.lproj/Localizable.strings
+++ b/Sources/UI/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"SnabblePay.Example" = "Example";
+

--- a/Sources/UI/Resources/en.lproj/Localizable.stringsdict
+++ b/Sources/UI/Resources/en.lproj/Localizable.stringsdict
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+  <dict/>
+</plist>

--- a/Tests/UI/ExampleTests.swift
+++ b/Tests/UI/ExampleTests.swift
@@ -1,0 +1,16 @@
+//
+//  ExampleTests.swift
+//  
+//
+//  Created by Andreas Osberghaus on 2022-12-16.
+//
+
+import XCTest
+@testable import SnabblePayUI
+
+final class ExampleTests: XCTestCase {
+
+    func testExample() throws {
+        XCTAssertEqual(Example.text, "Example")
+    }
+}


### PR DESCRIPTION
* set `defaultLocalization` to `en`
* integrate phrase project with locales german and english
* english is the fallback language in `.phrase.yml` to match the `defaultLocalization` of the package
* add a testTarget for `SnabblePayUI`
