### PR TITLE
Farbe der Snabble Pay Karte anpassen

### DIFF
--- a/Example/SnabblePayExample/Utilities/Modifiers.swift
+++ b/Example/SnabblePayExample/Utilities/Modifiers.swift
@@ -60,7 +60,7 @@ struct CardStyle: ViewModifier {
     func body(content: Content) -> some View {
         content
             .frame(minWidth: 320, minHeight: 220, maxHeight: 220)
-            .background(self.top ? Self.topMaterial : Self.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+            .background(Color(white: 1, opacity: 0.66), in: RoundedRectangle(cornerRadius: 12))
             .rotation3DEffect(.degrees(motionManager.xCoordinate * 20), axis: (x: 0, y: 1, z: 0))
             .padding([.leading, .trailing])
             .shadow(radius: 4, y: 2)

--- a/Example/SnabblePayExample/Views/CardView.swift
+++ b/Example/SnabblePayExample/Views/CardView.swift
@@ -62,7 +62,7 @@ struct CardView: View {
             Spacer()
             VStack(alignment: .leading, spacing: 8) {
                 Text(model.ibanString)
-                    .font(.headline)
+                    .font(.custom("Menlo", size: 16))
                     .fontWeight(.bold)
                 HStack {
                     Text(model.account.holderName)

--- a/Example/SnabblePayExample/Views/CardView.swift
+++ b/Example/SnabblePayExample/Views/CardView.swift
@@ -49,7 +49,7 @@ struct CardView: View {
             Image(systemName: "qrcode")
                 .resizable()
                 .scaledToFit()
-                .foregroundColor(colorScheme == .dark ? .white : .black)
+                .foregroundColor(.secondary)
         }
     }
     var body: some View {
@@ -60,34 +60,32 @@ struct CardView: View {
                 .padding([.top])
                 .frame(width: toggleSize ? 160 : 60)
             Spacer()
-            VStack(alignment: .leading, spacing: 8) {
+
+            VStack(alignment: .leading, spacing: 2) {
                 Text(model.ibanString)
                     .font(.custom("Menlo", size: 16))
                     .fontWeight(.bold)
                 HStack {
                     Text(model.account.holderName)
-                        .font(.caption)
                     Spacer()
                     if topAnimation {
                         ZStack(alignment: .trailing) {
                             Text(model.customName)
-                                .font(.caption)
                                 .opacity(opactiyOn)
                             Text(model.account.bank)
-                                .font(.caption)
                                 .opacity(opactiyOff)
                         }
+                        
                    } else {
                        Text(expand || !model.hasCustomName ? model.account.bank : model.customName)
-                           .font(.caption)
                     }
                 }
-                
+                .font(.caption)
             }
-            .padding([.leading, .trailing])
-            .padding([.bottom], model.autostart ? 16 : 8)
-            .foregroundColor(Color.black)
+            .padding([.leading, .trailing], 20)
+            .padding([.bottom], 10)
         }
+        .foregroundColor(Color.black)
         .cardStyle(top: model.autostart)
         .onChange(of: scenePhase) { newPhase in
             guard model.autostart else {

--- a/Example/SnabblePayExample/Views/CardView.swift
+++ b/Example/SnabblePayExample/Views/CardView.swift
@@ -86,7 +86,7 @@ struct CardView: View {
             }
             .padding([.leading, .trailing])
             .padding([.bottom], model.autostart ? 16 : 8)
-            .foregroundColor(model.autostart ? .primary : .secondary)
+            .foregroundColor(Color.black)
         }
         .cardStyle(top: model.autostart)
         .onChange(of: scenePhase) { newPhase in


### PR DESCRIPTION
https://snabble.atlassian.net/browse/APPS-1264

- Der Background der Karte ist nun `Color.white` mit Opacity `0.66`, da der Wert `0.5` wie im Ticket zu durchsichtig erscheint, besonders wenn mehrere Karten im Stapel angezeigt werden.
- Es wird der alte Font `Menlo` für die IBAN verwendet.
- Diverse Abstände wurden dem Figma-Design entsprechend angepasst.

### Definition of Done
- [x] Anforderungen erfüllt
- [x] Deployment Target
- [x] Home-Button vs. Face-ID Device (SafeArea Guides)
- [x] Dark / Light Mode
- [x] Product Owner Review
